### PR TITLE
Pin SMW version for older MW versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,35 +18,35 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            smw_version: dev-master
+            smw_version: 5.1.0
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
-            smw_version: dev-master
+            smw_version: 5.1.0
             php_version: 8.1
             database_type: postgres
             database_image: "postgres:14"
             coverage: false
             experimental: false
           - mediawiki_version: '1.40'
-            smw_version: dev-master
+            smw_version: 5.1.0
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
           - mediawiki_version: '1.41'
-            smw_version: dev-master
+            smw_version: 5.1.0
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            smw_version: dev-master
+            smw_version: 5.1.0
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"


### PR DESCRIPTION
The current dev-master of SMW requires 1.43+, see
SemanticMediaWiki/SemanticMediaWiki#6170

Based on SemanticMediaWiki/SemanticWatchlist#125